### PR TITLE
Flicker fix ie10 fix

### DIFF
--- a/js/heidelberg/heidelberg.js
+++ b/js/heidelberg/heidelberg.js
@@ -50,7 +50,7 @@
     // PRIVATE VARIABLES
     // Main element always a jQuery object
     this.el = (el instanceof $) ? el : $(el);
-
+    this.el.attr('data-useragent', navigator.userAgent); // Add user agent attribute to HTMLElement - used in CSS selection ( for IE10 detection )
     // RUN
     this.init();
 

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -61,11 +61,11 @@ $_right: odd
 
 // active left page
 .Heidelberg-Page.is-active:nth-child(#{$_left})
-  transform: rotateY(5deg)
+  transform: rotateY(10deg)
 
 // active right page
 .Heidelberg-Page.is-active:nth-child(#{$_right})
-  transform: rotateY(-5deg)
+  transform: rotateY(-10deg)
 
   // left pages after active spread
 .Heidelberg-Page.is-active:nth-child(#{$_right}) ~ .Heidelberg-Page:nth-child(#{$_left})

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -120,3 +120,18 @@ $_right: odd
 // Needs to be on own line to work in IE8
 .no-csstransforms3d .Heidelberg-Page.with-Spread.is-active + .Heidelberg-Page.with-Spread.is-active .Heidelberg-Spread
   left: -100%
+
+// Internet 10 only selector - checks Heidelberg HTMLElement attribute: data-useragent
+.Heidelberg-Book[data-useragent*='MSIE 10.0']
+
+  .Heidelberg-Page
+    opacity: 0
+
+  .Heidelberg-Page.is-active
+    transition: transform $Heidelberg-duration ease, opacity $Heidelberg-duration ease
+    opacity: 1
+
+  .Heidelberg-Page.was-active
+    transition-delay: 2s
+    transition: transform $Heidelberg-duration ease, opacity $Heidelberg-duration ease
+    opacity: 0


### PR DESCRIPTION
Fixes the following: 

1) OSX / Chrome: Page flickering during transition ( more apparent on low spec laptops )

2) Windows: Internet Explorer 10 ( only) - page turn was not working properly / target pages were 'clunking' in after a transition. This fix aims to fix that issue by having the outgoing pages fade in / out. Not ideal - but much nicer than the current implementation.
