### PR TITLE
Feature/heidelberg update

### DIFF
--- a/js/heidelberg/heidelberg.js
+++ b/js/heidelberg/heidelberg.js
@@ -157,8 +157,13 @@
       return;
     }
 
-    index.activeRight = els.pagesActive.eq(1).index();
-    index.activeLeft  = index.activeRight - 1;
+    if ( options.hasSpreads ) {
+      index.activeRight = els.pagesActive.eq(1).index();
+      index.activeLeft  = index.activeRight - 1;
+    } else {// Single page spreads ( JHome )
+      index.activeLeft  = els.pagesActive.eq(0).index(); // Note about fix: the double spread code above caused code to wrap to bottom of array . This is the fix for double spreads.
+      index.activeRight = index.activeLeft + 1;
+    }
 
     var isFirstPage = els.pages.first().index() == index.activeLeft && direction == 'back';
     var isLastPage  = els.pages.last().index() == index.activeRight && direction == 'forwards';
@@ -170,6 +175,7 @@
     if(typeof arg == 'number') {
       var isOdd         = arg & 1;
       var isRight       = options.canClose ? isOdd : !isOdd;
+
       index.targetRight = isRight ? arg : arg + 1;
       index.targetLeft  = index.targetRight - 1;
 
@@ -186,10 +192,23 @@
         index.target        = index.targetRight;
         index.targetSibling = index.target - 1;
       }
+
+      if ( ! options.hasSpreads )
+      {
+        index.target = index.target - 1;
+        index.targetSibling = index.targetSibling - 1;
+      }
+
     }
     else {
       index.target        = direction == 'forwards' ? index.activeRight + 1 : index.activeLeft - 1;
       index.targetSibling = direction == 'forwards' ? index.activeRight + 2 : index.activeLeft - 2;
+    }
+
+    // JHome - double spreads - Fix for 'is-active' pages not being correctly offset from the stars
+    if ( ! options.hasSpreads && direction == 'forwards' && index.target == 2 ) {
+      index.target = 1;
+      index.targetSibling = 2;
     }
 
     els.pagesAnimatingOut = (direction == 'back') ? els.pagesActive.first() : els.pagesActive.last();

--- a/js/heidelberg/heidelberg.js
+++ b/js/heidelberg/heidelberg.js
@@ -50,7 +50,7 @@
     // PRIVATE VARIABLES
     // Main element always a jQuery object
     this.el = (el instanceof $) ? el : $(el);
-
+    this.el.attr('data-useragent', navigator.userAgent); // Add user agent attribute to HTMLElement - used in CSS selection ( for IE10 detection )
     // RUN
     this.init();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heidelberg",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A Sass powered animated book plugin",
   "main": "js/heidelberg/heidelberg.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heidelberg",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A Sass powered animated book plugin",
   "main": "js/heidelberg/heidelberg.js",
   "scripts": {

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -45,14 +45,25 @@ $_right: odd
 .Heidelberg-Page:nth-child(#{$_left})
   transform-origin: 100%
   left: 0
+  &:hover
+    cursor: w-resize
+
 
 // right pages
 .Heidelberg-Page:nth-child(#{$_right})
   transform-origin: 0
   right: 0
+  &:hover // roll
+    cursor: e-resize
 
   // right pages before active spread
   transform: rotateY(-180deg)
+
+// disable roll over queue for last spread
+.Heidelberg-Page:nth-last-child(2)
+  opacity: 0
+  &:hover
+    cursor: auto
 
 // active spread
 .Heidelberg-Page.is-active
@@ -62,10 +73,13 @@ $_right: odd
 // active left page
 .Heidelberg-Page.is-active:nth-child(#{$_left})
   transform: rotateY(10deg)
-
+  &:hover
+    transform: rotateY(15deg)
 // active right page
 .Heidelberg-Page.is-active:nth-child(#{$_right})
   transform: rotateY(-10deg)
+  &:hover
+    transform: rotateY(15deg)
 
   // left pages after active spread
 .Heidelberg-Page.is-active:nth-child(#{$_right}) ~ .Heidelberg-Page:nth-child(#{$_left})

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -61,11 +61,11 @@ $_right: odd
 
 // active left page
 .Heidelberg-Page.is-active:nth-child(#{$_left})
-  transform: rotateY(5deg)
+  transform: rotateY(10deg)
 
 // active right page
 .Heidelberg-Page.is-active:nth-child(#{$_right})
-  transform: rotateY(-5deg)
+  transform: rotateY(-10deg)
 
   // left pages after active spread
 .Heidelberg-Page.is-active:nth-child(#{$_right}) ~ .Heidelberg-Page:nth-child(#{$_left})

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -120,3 +120,18 @@ $_right: odd
 // Needs to be on own line to work in IE8
 .no-csstransforms3d .Heidelberg-Page.with-Spread.is-active + .Heidelberg-Page.with-Spread.is-active .Heidelberg-Spread
   left: -100%
+
+// Internet 10 only selector - checks Heidelberg HTMLElement attribute: data-useragent
+.Heidelberg-Book[data-useragent*='MSIE 10.0']
+
+  .Heidelberg-Page
+    opacity: 0
+
+  .Heidelberg-Page.is-active
+    transition: transform $Heidelberg-duration ease, opacity $Heidelberg-duration ease
+    opacity: 1
+
+  .Heidelberg-Page.was-active
+    transition-delay: 2s
+    transition: transform $Heidelberg-duration ease, opacity $Heidelberg-duration ease
+    opacity: 0

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -45,7 +45,7 @@ $_right: odd
 .Heidelberg-Page:nth-child(#{$_left})
   transform-origin: 100%
   left: 0
-  &:hover
+  //&:hover
     cursor: w-resize
 
 
@@ -53,18 +53,18 @@ $_right: odd
 .Heidelberg-Page:nth-child(#{$_right})
   transform-origin: 0
   right: 0
-  &:hover // roll
+  //&:hover // roll
     cursor: e-resize
 
   // right pages before active spread
   transform: rotateY(-180deg)
 
-.Heidelberg-Page:nth-child(2)
+//.Heidelberg-Page:nth-child(2)
   &:hover
     cursor: auto
 
 // disable roll over queue for last spread
-.Heidelberg-Page:nth-last-child(2)
+//.Heidelberg-Page:nth-last-child(2)
   &:hover
     cursor: auto
 

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -82,7 +82,7 @@ $_right: odd
 .Heidelberg-Page.is-active:nth-child(#{$_right})
   transform: rotateY(-10deg)
   &:hover
-    transform: rotateY(15deg)
+    transform: rotateY(-15deg)
 
   // left pages after active spread
 .Heidelberg-Page.is-active:nth-child(#{$_right}) ~ .Heidelberg-Page:nth-child(#{$_left})

--- a/sass/heidelberg/_heidelberg-plugin.sass
+++ b/sass/heidelberg/_heidelberg-plugin.sass
@@ -59,9 +59,12 @@ $_right: odd
   // right pages before active spread
   transform: rotateY(-180deg)
 
+.Heidelberg-Page:nth-child(2)
+  &:hover
+    cursor: auto
+
 // disable roll over queue for last spread
 .Heidelberg-Page:nth-last-child(2)
-  opacity: 0
   &:hover
     cursor: auto
 


### PR DESCRIPTION
Fix for J-Home single page spreads now work correctly
Fix for Internet Explorer 10
Fix for page flicker on some GPU's

This is currently running through QA, and will be merged into master if it passes. Lostmyname/heidelberg master will then be linked from Monkey.

The most important QA element of this update is: LMN content to work exactly as it currently does ( with update for IE10 ) . 

JHome is an incremental fix which work much better with single page spreads - but still needs some testing ( this should not impact LMN content ) .